### PR TITLE
Use worldborder API instead of an incorrect calculation

### DIFF
--- a/randomteleport-hook/src/main/java/de/themoep/randomteleport/hook/WorldborderHook.java
+++ b/randomteleport-hook/src/main/java/de/themoep/randomteleport/hook/WorldborderHook.java
@@ -42,14 +42,5 @@ public interface WorldborderHook extends PluginHook {
      * @param location The location to check
      * @return True if it is inside (or there is no border), false if not
      */
-    default boolean isInsideBorder(Location location) {
-        Location center = getCenter(location.getWorld());
-        if (center != null) {
-            double radius = getBorderRadius(location.getWorld());
-            if (radius > 0) {
-                return center.distanceSquared(location) <= radius * radius;
-            }
-        }
-        return true;
-    }
+    boolean isInsideBorder(Location location);
 }

--- a/randomteleport-plugin-hooks/worldborder/src/main/java/de/themoep/randomteleport/hook/plugin/WorldBorderHook.java
+++ b/randomteleport-plugin-hooks/worldborder/src/main/java/de/themoep/randomteleport/hook/plugin/WorldBorderHook.java
@@ -45,6 +45,12 @@ public class WorldBorderHook implements WorldborderHook {
     }
 
     @Override
+    public boolean isInsideBorder(Location location) {
+        BorderData data = plugin.getWorldBorder(location.getWorld().getName());
+        return data.insideBorder(location);
+    }
+
+    @Override
     public Plugin getPlugin() {
         return plugin;
     }


### PR DESCRIPTION
This calculation is wrong when I tested with a rectangular, 21,600x10,800 world border.  I changed the code to use the WorldBorder API to determine whether the position is in the worldborder.