### PR TITLE
Use player world as preset when using rtp without parameters

### DIFF
--- a/randomteleport-plugin-hooks/griefdefender/pom.xml
+++ b/randomteleport-plugin-hooks/griefdefender/pom.xml
@@ -21,6 +21,7 @@
             <groupId>com.griefdefender</groupId>
             <artifactId>api</artifactId>
             <version>2.1.0-20220122.032038-5</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.bukkit</groupId>

--- a/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleportCommand.java
+++ b/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleportCommand.java
@@ -41,7 +41,14 @@ public class RandomTeleportCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
             if (sender instanceof Player) {
-                runPreset("default", sender, (Player) sender, ((Player) sender).getLocation());
+                Player player = (Player) sender;
+                String preset = "default";
+                if (plugin.getConfig().getBoolean("use-player-world-as-preset", false)) {
+                    String worldName = player.getWorld().getName().toLowerCase();
+                    if (presetExistsInConfig(worldName))
+                        preset = worldName;
+                }
+                runPreset(preset, sender, player, player.getLocation());
                 return true;
             }
         } else if (args.length == 1) {
@@ -88,7 +95,7 @@ public class RandomTeleportCommand implements CommandExecutor {
             );
         } else if (sender != target && !sender.hasPermission("randomteleport.tpothers")) {
             plugin.sendMessage(sender, "error.no-permission.tp-others", "perm", "randomteleport.tpothers");
-        } else if (plugin.getConfig().getString("presets." + preset) == null) {
+        } else if (!presetExistsInConfig(preset)) {
             plugin.sendMessage(sender, "error.preset-doesnt-exist", "preset", preset);
         } else {
             if (sender == target) {
@@ -107,6 +114,10 @@ public class RandomTeleportCommand implements CommandExecutor {
                 plugin.getLogger().log(Level.SEVERE, "Error while parsing preset " + preset, e);
             }
         }
+    }
+
+    private boolean presetExistsInConfig(String preset) {
+        return plugin.getConfig().getString("presets." + preset) != null;
     }
 
     private static Location getLocation(CommandSender sender) {

--- a/randomteleport-plugin/src/main/resources/config.yml
+++ b/randomteleport-plugin/src/main/resources/config.yml
@@ -4,6 +4,9 @@ lang: en
 debug: true
 # Delay in ticks between checking chunks when searching
 
+# Should we search for a preset named like the world the player is in when using /rtp without parameters?
+use-player-world-as-preset: false
+
 # Blocks to teleport on in normal mode
 safe-blocks:
 - sand


### PR DESCRIPTION
This PR adds a feature that allows to set "world presets".

**How it works:**
When the feature is enabled (off by default) and an user uses /rtp (without parameters) it tries to find a preset named like the worldname the player is currently in.
If the world isnt found, the default preset is used.

**Why is this useful?**
Lets say we have three worlds: spawn, mine, plotworld. 
Spawn is just a 1000x1000 world (We dont want players getting rtped there). 
If new players use rtp right after spawning, we execute rtp -w plotworld. (As the preset named spawn executes this command)
When players are in the plotworld, rtp executes rtp -w plotworld
When players are in the mine, rtp executes rtp -w mine.

Without this feature players would have to use /rtp plotworld etc. which is not very intuitive.