### PR TITLE
Removing hardcoded "s" from cooldown placeholder

### DIFF
--- a/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleport.java
+++ b/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleport.java
@@ -387,7 +387,7 @@ public class RandomTeleport extends JavaPlugin implements RandomTeleportAPI {
         }
 
         if (cooldown > 0 && cooldown < searcher.getCooldown()) {
-            sendMessage(searcher.getTargets(), "error.cooldown", "cooldown_text", (searcher.getCooldown() - cooldown) + "s");
+            sendMessage(searcher.getTargets(), "error.cooldown", "cooldown_text", (searcher.getCooldown() - cooldown));
             return null;
         }
         sendMessage(searcher.getTargets(), "search", "worldname", searcher.getCenter().getWorld().getName());

--- a/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleport.java
+++ b/randomteleport-plugin/src/main/java/de/themoep/randomteleport/RandomTeleport.java
@@ -387,7 +387,7 @@ public class RandomTeleport extends JavaPlugin implements RandomTeleportAPI {
         }
 
         if (cooldown > 0 && cooldown < searcher.getCooldown()) {
-            sendMessage(searcher.getTargets(), "error.cooldown", "cooldown_text", (searcher.getCooldown() - cooldown));
+            sendMessage(searcher.getTargets(), "error.cooldown", "cooldown_text", Integer.toString(searcher.getCooldown() - cooldown));
             return null;
         }
         sendMessage(searcher.getTargets(), "search", "worldname", searcher.getCenter().getWorld().getName());

--- a/randomteleport-plugin/src/main/resources/languages/lang.en.yml
+++ b/randomteleport-plugin/src/main/resources/languages/lang.en.yml
@@ -12,7 +12,7 @@ sign:
 error:
    location: "&4Error: &cRandomTeleport could not find a safe location!"
    teleport: "&4Error: &cRandomTeleport could not teleport you to X: {x} Y: {y} Z: {z}!"
-   cooldown: "&cYou have to wait {cooldown_text} before using this RandomTeleport again!"
+   cooldown: "&cYou have to wait {cooldown_text}s before using this RandomTeleport again!"
    parse-error: "&cError while parsing option &f{option}&c with value &f{value}&c: {error}"
    not-found: "&cCould not find &f{what}&c!"
    player-not-found: "&cCould not find a player with the name &f{what}&c!"


### PR DESCRIPTION
This PR fixes the cooldown placeholder: currently, an "s" is hard-coded added to the cooldown size. This making the message less configurable.